### PR TITLE
Adapt example to new okteto manifest syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # terminal
+
 Web-based terminal for Kubernetes development
 
 Deploy a web-based terminal in your Kubernetes cluster. 
@@ -18,12 +19,10 @@ It is also configured with such `bash` aliases:
         ktp="watch kubectl top pods"
         ktc="watch kubectl top pods --containers"
 
-# Deploy it in Okteto Cloud
+# Deploy
 
-1. Login to [Okteto Cloud](https://cloud.okteto.com).
-1. Deploy the helm chart: 
+1. Login to your Okteto instance
+2. Deploy with `okteto deploy`
 
-        helm install terminal -f values.yaml
-        
-
-After deploying, go to the Okteto Cloud in your browser and click on the URL. You'll need to confirm your okteto identity to access the terminal. The terminal will have access to everything in your namespace.
+After deploying, go to the Okteto UI in your browser and click on the URL.
+The terminal will have access to everything in your namespace.

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -17,12 +17,6 @@ spec:
       - image: "{{ .Values.image }}:{{ .Chart.AppVersion }}"
         imagePullPolicy: IfNotPresent
         name: terminal
-        env:
-          - name: TERMINAL_CREDENTIAL
-            valueFrom:
-              secretKeyRef:
-                name: terminal-credential
-                key: credential
         ports:
         - containerPort: {{ .Values.port }}
           protocol: TCP

--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -1,37 +1,18 @@
-{{- $fullName := include "terminal.fullname" . -}}
-{{- $svcPort := .Values.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  labels:
-    {{- include "terminal.labels" . | nindent 4 }}
-  annotations:
-    {{- with .Values.ingress.annotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
   name: {{ include "terminal.fullname" . }}
+  annotations:
+    dev.okteto.com/generate-host: "true"
+    dev.okteto.com/auto-ingress: "private"
 spec:
-{{- if .Values.ingress.tls }}
-  tls:
-  {{- range .Values.ingress.tls }}
-    - hosts:
-      {{- range .hosts }}
-        - {{ . | quote }}
-      {{- end }}
-      secretName: {{ .secretName }}
-  {{- end }}
-{{- end }}
   rules:
-  {{- range .Values.ingress.hosts }}
-    - host: {{ . | quote }}
-      http:
+    - http:
         paths:
           - path: /
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
-  {{- end }}
+              service:
+                name: {{ include "terminal.fullname" . }}
+                port:
+                  number: 8080
+            pathType: ImplementationSpecific

--- a/chart/values-okteto.yaml
+++ b/chart/values-okteto.yaml
@@ -1,4 +1,0 @@
-ingress:
-  annotations: 
-    # let okteto dynamically generate the ingress hostname
-    dev.okteto.com/generate-host: "true"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -2,10 +2,3 @@ image: okteto/terminal
 port: 8080
 nameOverride: ""
 fullnameOverride: "" 
-
-ingress:
-  enabled: true
-  annotations: {}
-  hosts:
-    - terminal.local
-  tls: []

--- a/okteto.yml
+++ b/okteto.yml
@@ -1,2 +1,2 @@
-name: terminal
-image: okteto/terminal
+deploy:
+  - helm upgrade --install terminal ./chart


### PR DESCRIPTION
This PR adapts the sample to use the new okteto manifest.
It also implements the following improvements:
- Expose the app behind a private endpoint to avoid credential management
- Simplify the config to just works in Okteto